### PR TITLE
支持 AI 教育列表页视频解析和勾选下载

### DIFF
--- a/internal/dl/parse_url.go
+++ b/internal/dl/parse_url.go
@@ -1,6 +1,8 @@
 package dl
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -51,6 +53,10 @@ func parseURL(link string, audio bool, random bool, useBackup bool) ([]string, e
 		return configURLList, nil
 	}
 
+	if path == AIEducationListPath {
+		return parseAIEducationListURL(parsedURL, random)
+	}
+
 	configInfo, ok := RESOURCES_MAP[path]
 	if !ok {
 		return configURLList, fmt.Errorf("invalid url path: %s", path)
@@ -89,6 +95,281 @@ func parseURL(link string, audio bool, random bool, useBackup bool) ([]string, e
 		slog.Debug(fmt.Sprintf("audioURL = %s", audioURL))
 		configURLList = append(configURLList, audioURL)
 	}
+	return configURLList, nil
+}
+
+func pickServer(random bool) string {
+	if random {
+		return SERVER_LIST[rand.Intn(len(SERVER_LIST))]
+	}
+	return SERVER_LIST[0]
+}
+
+func sha256Hex(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
+func buildLibraryAdapterIndexURL(server string, libraryID string) string {
+	adapterPath := fmt.Sprintf("/v1/libraries/%s/contents/actions/full/adapter", libraryID)
+	hash := sha256Hex(adapterPath + "?sort_type=3")
+	return fmt.Sprintf(
+		"https://%s.ykt.cbern.com.cn/%s/api/zh-CN/%s/elearning_library%s/%s.json",
+		server,
+		AIEducationLibraryService,
+		AIEducationLibraryAppID,
+		adapterPath,
+		hash,
+	)
+}
+
+func fetchAIEducationListItems(indexURL string) ([]LibraryContentItem, error) {
+	data, err, statusOK := FetchJsonData(indexURL)
+	if err != nil || !statusOK {
+		return nil, fmt.Errorf("fetch ai education list index error: %v / status=%v", err, statusOK)
+	}
+
+	var library DataLibrary
+	if err := json.Unmarshal(data, &library); err != nil {
+		var items []LibraryContentItem
+		if itemErr := json.Unmarshal(data, &items); itemErr != nil {
+			return nil, err
+		}
+		return items, nil
+	}
+
+	parsedURL, err := url.Parse(indexURL)
+	if err != nil {
+		return nil, err
+	}
+	baseURL := parsedURL.Scheme + "://" + parsedURL.Host
+	var items []LibraryContentItem
+	for _, file := range library.Files {
+		fileURL := file
+		if strings.HasPrefix(file, "/") {
+			fileURL = baseURL + file
+		} else if !strings.HasPrefix(file, "http") {
+			fileURL = baseURL + "/" + file
+		}
+
+		partData, err, statusOK := FetchJsonData(fileURL)
+		if err != nil || !statusOK {
+			slog.Warn(fmt.Sprintf("fetch ai education list file error: %v / status=%v", err, statusOK))
+			continue
+		}
+		var partItems []LibraryContentItem
+		if err := json.Unmarshal(partData, &partItems); err != nil {
+			slog.Warn(fmt.Sprintf("parse ai education list file error: %v", err))
+			continue
+		}
+		items = append(items, partItems...)
+	}
+	return items, nil
+}
+
+func splitDefaultTags(raw string) []string {
+	raw = unescapeQueryValue(raw)
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+
+	parts := strings.Split(raw, "/")
+	tags := []string{}
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" || strings.EqualFold(part, "all") {
+			continue
+		}
+		tags = append(tags, part)
+	}
+	return tags
+}
+
+func unescapeQueryValue(raw string) string {
+	for range 2 {
+		decoded, err := url.QueryUnescape(raw)
+		if err != nil || decoded == raw {
+			break
+		}
+		raw = decoded
+	}
+	return raw
+}
+
+func parseEmbeddedListQuery(raw string) url.Values {
+	values := url.Values{}
+	if raw == "" {
+		return values
+	}
+
+	parsed, err := url.ParseQuery(raw)
+	if err == nil {
+		return parsed
+	}
+
+	for _, part := range strings.Split(raw, "&") {
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		values.Add(strings.TrimSpace(key), strings.TrimSpace(value))
+	}
+	return values
+}
+
+func parseAIEducationListParams(values url.Values) (string, []string, error) {
+	contentID := unescapeQueryValue(strings.TrimSpace(values.Get("content_id")))
+	if contentID == "" {
+		return "", nil, fmt.Errorf("missing content_id")
+	}
+
+	defaultTagCandidates := []string{values.Get("defaultTag")}
+	libraryID := contentID
+	if cleanID, embeddedQuery, found := strings.Cut(contentID, "?"); found {
+		libraryID = cleanID
+		embeddedValues := parseEmbeddedListQuery(embeddedQuery)
+		defaultTagCandidates = append(defaultTagCandidates, embeddedValues.Get("defaultTag"))
+	} else if cleanID, embeddedQuery, found := strings.Cut(contentID, "&"); found {
+		libraryID = cleanID
+		embeddedValues := parseEmbeddedListQuery(embeddedQuery)
+		defaultTagCandidates = append(defaultTagCandidates, embeddedValues.Get("defaultTag"))
+	}
+
+	libraryID = strings.Trim(strings.TrimSpace(libraryID), "/")
+	if libraryID == "" {
+		return "", nil, fmt.Errorf("missing content_id")
+	}
+
+	var selectedTags []string
+	for _, candidate := range defaultTagCandidates {
+		tags := splitDefaultTags(candidate)
+		if len(tags) > len(selectedTags) {
+			selectedTags = tags
+		}
+	}
+	return libraryID, selectedTags, nil
+}
+
+func containsTag(item LibraryContentItem, tag string) bool {
+	if tag == "" {
+		return true
+	}
+	for _, itemTag := range item.Tags {
+		if itemTag.ID == tag || itemTag.Code == tag || itemTag.Title == tag {
+			return true
+		}
+	}
+	return false
+}
+
+func filterAIEducationVideoItems(items []LibraryContentItem, selectedTags []string) ([]LibraryContentItem, string) {
+	allVideos := []LibraryContentItem{}
+	for _, item := range items {
+		if isVideoLibraryContent(item) {
+			allVideos = append(allVideos, item)
+		}
+	}
+	if len(selectedTags) == 0 {
+		return allVideos, ""
+	}
+
+	for i := len(selectedTags) - 1; i >= 0; i-- {
+		tag := selectedTags[i]
+		videoItems := []LibraryContentItem{}
+		for _, item := range allVideos {
+			if containsTag(item, tag) {
+				videoItems = append(videoItems, item)
+			}
+		}
+		if len(videoItems) > 0 {
+			return videoItems, tag
+		}
+	}
+	return []LibraryContentItem{}, selectedTags[len(selectedTags)-1]
+}
+
+func isVideoLibraryContent(item LibraryContentItem) bool {
+	if item.ResourceType == AIEducationVideoType {
+		return true
+	}
+	if item.Type == AIEducationVideoType {
+		return true
+	}
+	for _, contentType := range item.ContentTypes {
+		if contentType == AIEducationVideoType {
+			return true
+		}
+	}
+	return false
+}
+
+func parsePositiveInt(values url.Values, keys []string, defaultValue int) int {
+	for _, key := range keys {
+		value, err := strconv.Atoi(values.Get(key))
+		if err == nil && value > 0 {
+			return value
+		}
+	}
+	return defaultValue
+}
+
+func isTruthy(raw string) bool {
+	raw = strings.TrimSpace(strings.ToLower(raw))
+	return raw == "1" || raw == "true" || raw == "yes" || raw == "all"
+}
+
+func sliceListPage(items []LibraryContentItem, values url.Values) []LibraryContentItem {
+	if isTruthy(values.Get("all")) || isTruthy(values.Get("downloadAll")) {
+		return items
+	}
+
+	pageSize := parsePositiveInt(values, []string{"pageSize", "page_size", "size", "limit"}, AIEducationDefaultPageSize)
+	page := parsePositiveInt(values, []string{"page", "pageNum", "pageNo"}, 1)
+	start := (page - 1) * pageSize
+	if start >= len(items) {
+		return []LibraryContentItem{}
+	}
+	end := start + pageSize
+	if end > len(items) {
+		end = len(items)
+	}
+	return items[start:end]
+}
+
+func parseAIEducationListURL(parsedURL *url.URL, random bool) ([]string, error) {
+	queryParams := parsedURL.Query()
+	libraryID, selectedTags, err := parseAIEducationListParams(queryParams)
+	if err != nil {
+		return nil, err
+	}
+
+	server := pickServer(random)
+	indexURL := buildLibraryAdapterIndexURL(server, libraryID)
+	items, err := fetchAIEducationListItems(indexURL)
+	if err != nil {
+		return nil, err
+	}
+
+	videoItems, selectedTag := filterAIEducationVideoItems(items, selectedTags)
+	if selectedTag != "" {
+		slog.Info(fmt.Sprintf("AIEducation list selected tag %s", selectedTag))
+	}
+	videoItems = sliceListPage(videoItems, queryParams)
+
+	configInfo := RESOURCES_MAP["/AIEducation/detail"]
+	configURLList := []string{}
+	for _, item := range videoItems {
+		contentID := item.UnitID
+		if contentID == "" {
+			contentID = item.ID
+		}
+		if contentID == "" {
+			continue
+		}
+		configURLList = append(configURLList, fmt.Sprintf(configInfo.resources.basic, server, contentID))
+	}
+	slog.Info(fmt.Sprintf("AIEducation list expanded to %d video resources", len(configURLList)))
 	return configURLList, nil
 }
 

--- a/internal/dl/parse_url_test.go
+++ b/internal/dl/parse_url_test.go
@@ -1,0 +1,53 @@
+package dl
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestParseAIEducationListParamsCleansEmbeddedDefaultTag(t *testing.T) {
+	rawURL := "https://basic.smartedu.cn/AIEducation/list?content_id=1423337d-b3bd-4b92-855e-e137f330619a%3FdefaultTag%3D68122750-eba8-4561-92a5-8edc2f9b6ce7%2Fee364c85-c7af-4e11-9ad9-384719be30fe%2F9750e040-00bb-4611-a1cc-bd2f34dcf49b%2Fbca3f7c5-04ae-462b-bacb-08a735b752bf&defaultTag=68122750-eba8-4561-92a5-8edc2f9b6ce7%2Fee364c85-c7af-4e11-9ad9-384719be30fe%2F9750e040-00bb-4611-a1cc-bd2f34dcf49b%2F"
+
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	libraryID, tags, err := parseAIEducationListParams(parsedURL.Query())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if libraryID != "1423337d-b3bd-4b92-855e-e137f330619a" {
+		t.Fatalf("unexpected libraryID: %s", libraryID)
+	}
+	if len(tags) != 4 {
+		t.Fatalf("unexpected tags: %#v", tags)
+	}
+	if tags[len(tags)-1] != "bca3f7c5-04ae-462b-bacb-08a735b752bf" {
+		t.Fatalf("unexpected deepest tag: %s", tags[len(tags)-1])
+	}
+}
+
+func TestFilterAIEducationVideoItemsFallsBackToNearestParentTag(t *testing.T) {
+	items := []LibraryContentItem{
+		{
+			UnitID:       "video-1",
+			ResourceType: AIEducationVideoType,
+			Tags:         []ReadingTag{{ID: "parent"}},
+		},
+		{
+			UnitID:       "doc-1",
+			ResourceType: "assets_document",
+			Tags:         []ReadingTag{{ID: "child"}},
+		},
+	}
+
+	videos, tag := filterAIEducationVideoItems(items, []string{"parent", "child"})
+	if tag != "parent" {
+		t.Fatalf("unexpected fallback tag: %s", tag)
+	}
+	if len(videos) != 1 || videos[0].UnitID != "video-1" {
+		t.Fatalf("unexpected videos: %#v", videos)
+	}
+}

--- a/internal/dl/resources.go
+++ b/internal/dl/resources.go
@@ -12,6 +12,12 @@ var SERVER_LIST = []string{
 	"s-file-3",
 }
 
+const AIEducationListPath = "/AIEducation/list"
+const AIEducationLibraryService = "zxx"
+const AIEducationLibraryAppID = "e5649925-441d-4a53-b525-51a2f1c4e0a8"
+const AIEducationVideoType = "assets_video"
+const AIEducationDefaultPageSize = 12
+
 // 下载数据格式（后缀）
 var FORMAT_LIST = []FormatData{
 	{"文档(PDF)", "pdf", true, true},
@@ -130,6 +136,20 @@ var RESOURCES_MAP = map[string]ResourceData{
 			// https://s-file-1.ykt.cbern.com.cn/zxx/ndrv2/resources/78605dce-97f6-62b7-6cb2-ac41ffd9467b.json
 			basic: "https://%s.ykt.cbern.com.cn/zxx/ndrv2/resources/%s.json",
 		},
+	},
+	"/AIEducation/detail": {
+		name:     "人工智能教育>视频资源",
+		params:   []string{"contentId"},
+		examples: []string{},
+		resources: ResourceInfo{
+			basic: "https://%s.ykt.cbern.com.cn/zxx/ndrs/special_edu/resources/details/%s.json",
+		},
+	},
+	AIEducationListPath: {
+		name:      "AIEducation list",
+		params:    []string{"content_id"},
+		examples:  []string{},
+		resources: ResourceInfo{},
 	},
 	// "/syncClassroom/examinationpapers": {
 	// 	name:     "课程教学>教师授课备课>习题资源", // 数据是json 忽略
@@ -385,6 +405,16 @@ type ReadingItem struct {
 	ResourceType string       `json:"resource_type"`
 	Title        string       `json:"title"`
 	Description  string       `json:"description"`
+	Tags         []ReadingTag `json:"tags"`
+}
+
+type LibraryContentItem struct {
+	ID           string       `json:"id"`
+	UnitID       string       `json:"unit_id"`
+	Type         string       `json:"type"`
+	ResourceType string       `json:"resource_type"`
+	Title        string       `json:"title"`
+	ContentTypes []string     `json:"content_types"`
 	Tags         []ReadingTag `json:"tags"`
 }
 

--- a/internal/ui/op_area.go
+++ b/internal/ui/op_area.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"path"
 	"strings"
@@ -122,6 +123,120 @@ func extractDownloadLinks(w fyne.Window, tab *container.AppTabs, linkItemMaps ma
 		return filteredURLs
 	}
 	return filteredURLs
+}
+
+func expandAIEducationListForVideoSelection(links []string) ([]string, bool) {
+	expanded := make([]string, 0, len(links))
+	hasListPage := false
+	for _, link := range links {
+		parsedURL, err := url.Parse(link)
+		if err == nil && parsedURL.Path == dl.AIEducationListPath {
+			hasListPage = true
+			query := parsedURL.Query()
+			if query.Get("all") == "" && query.Get("downloadAll") == "" {
+				query.Set("all", "1")
+				parsedURL.RawQuery = query.Encode()
+				link = parsedURL.String()
+			}
+		}
+		expanded = append(expanded, link)
+	}
+	return expanded, hasListPage
+}
+
+func formatVideoSize(size int64) string {
+	if size <= 0 {
+		return ""
+	}
+	const mb = 1024 * 1024
+	if size < mb {
+		return fmt.Sprintf("%.1f KB", float64(size)/1024)
+	}
+	return fmt.Sprintf("%.1f MB", float64(size)/mb)
+}
+
+func showVideoSelectionDialog(w fyne.Window, resources []dl.LinkData, pageSize int, startDownload func([]dl.LinkData), onCancel func()) {
+	selected := make([]bool, len(resources))
+	checks := make([]*widget.Check, len(resources))
+	checkContainer := container.NewVBox()
+	countLabel := widget.NewLabel("")
+
+	updateCount := func() {
+		count := 0
+		for _, checked := range selected {
+			if checked {
+				count++
+			}
+		}
+		countLabel.SetText(fmt.Sprintf("已选择 %d/%d 个视频", count, len(resources)))
+	}
+
+	for i, resource := range resources {
+		index := i
+		selected[index] = true
+		prefix := fmt.Sprintf("%03d.", i+1)
+		if pageSize > 0 {
+			prefix = fmt.Sprintf("第%d页 %03d.", i/pageSize+1, i+1)
+		}
+		label := fmt.Sprintf("%s %s", prefix, resource.Title)
+		if sizeText := formatVideoSize(resource.Size); sizeText != "" {
+			label = fmt.Sprintf("%s (%s)", label, sizeText)
+		}
+		check := widget.NewCheck(label, func(checked bool) {
+			selected[index] = checked
+			updateCount()
+		})
+		check.SetChecked(true)
+		checks[index] = check
+		checkContainer.Add(check)
+	}
+
+	selectAllButton := widget.NewButtonWithIcon("全选", theme.ConfirmIcon(), func() {
+		for i, check := range checks {
+			selected[i] = true
+			check.SetChecked(true)
+		}
+		updateCount()
+	})
+	clearAllButton := widget.NewButtonWithIcon("全不选", theme.CancelIcon(), func() {
+		for i, check := range checks {
+			selected[i] = false
+			check.SetChecked(false)
+		}
+		updateCount()
+	})
+
+	scroll := container.NewVScroll(checkContainer)
+	scroll.SetMinSize(fyne.NewSize(720, 420))
+	contentItems := []fyne.CanvasObject{
+		widget.NewLabel(fmt.Sprintf("解析到 %d 个视频，请勾选要下载的内容。", len(resources))),
+	}
+	if pageSize > 0 && len(resources) > pageSize {
+		contentItems = append(contentItems, widget.NewLabel(fmt.Sprintf("网页每页通常是 %d 个视频；第 2 页一般对应 %03d-%03d。", pageSize, pageSize+1, pageSize*2)))
+	}
+	contentItems = append(contentItems, container.NewHBox(selectAllButton, clearAllButton, countLabel), scroll)
+	content := container.NewVBox(contentItems...)
+	updateCount()
+
+	dialog.NewCustomConfirm("选择要下载的视频", "开始下载", "取消", content, func(ok bool) {
+		if !ok {
+			onCancel()
+			return
+		}
+
+		selectedResources := make([]dl.LinkData, 0, len(resources))
+		for i, checked := range selected {
+			if checked {
+				selectedResources = append(selectedResources, resources[i])
+			}
+		}
+		if len(selectedResources) == 0 {
+			dialog.NewInformation("提示", "请至少选择 1 个视频", w).Show()
+			onCancel()
+			return
+		}
+		startDownload(selectedResources)
+	}, w).Show()
 }
 
 func CreateOperationArea(w fyne.Window, tab *container.AppTabs, linkItemMaps map[string][]dl.LinkItem, maxConcurrency int) *fyne.Container {
@@ -275,23 +390,50 @@ func CreateOperationArea(w fyne.Window, tab *container.AppTabs, linkItemMaps map
 		}
 		downloadPath := extractDownloadInfo(w, pathEntry, defaultPath, pathComment)
 		headers := initHeaders(loginEntry.Text)
+		useBackup := backupCheckbox.Checked
+		enableLog := logCheckbox.Checked
 
 		// 下载进行中禁止再次点击
 		downloadButton.Disable()
 		downloadVideoButton.Disable()
+		progressLabel.SetText("正在解析视频资源...")
 
-		formatList := dl.FORMAT_VIDEO
-		resourceURLs := dl.ExtractResources(filteredURLs, formatList, random, backupCheckbox.Checked, true)
-		if len(resourceURLs) == 0 {
-			dialog.NewError(fmt.Errorf("未解析到有效资源"), w).Show()
-			downloadButton.Enable()
-			downloadVideoButton.Enable()
-			return
+		videoLinks, hasAIEducationListPage := expandAIEducationListForVideoSelection(filteredURLs)
+		selectionPageSize := 0
+		if hasAIEducationListPage {
+			selectionPageSize = dl.AIEducationDefaultPageSize
 		}
+		go func() {
+			formatList := dl.FORMAT_VIDEO
+			resourceURLs := dl.ExtractResources(videoLinks, formatList, random, useBackup, true)
+			fyne.Do(func() {
+				if len(resourceURLs) == 0 {
+					dialog.NewError(fmt.Errorf("未解析到有效资源"), w).Show()
+					downloadButton.Enable()
+					downloadVideoButton.Enable()
+					progressLabel.SetText("当前无下载内容")
+					return
+				}
 
-		// 下载视频
-		downloadManager := dl.NewDownloadManager(w, progressBar, progressLabel, downloadPath, resourceURLs)
-		downloadManager.StartDownload(downloadButton, downloadVideoButton, headers, logCheckbox.Checked, true, maxConcurrency)
+				startDownload := func(selectedResources []dl.LinkData) {
+					downloadManager := dl.NewDownloadManager(w, progressBar, progressLabel, downloadPath, selectedResources)
+					downloadManager.StartDownload(downloadButton, downloadVideoButton, headers, enableLog, true, maxConcurrency)
+				}
+				cancelDownload := func() {
+					downloadButton.Enable()
+					downloadVideoButton.Enable()
+					progressLabel.SetText("已取消视频下载")
+				}
+
+				if len(resourceURLs) == 1 {
+					startDownload(resourceURLs)
+					return
+				}
+
+				progressLabel.SetText(fmt.Sprintf("解析到 %d 个视频，请选择要下载的内容", len(resourceURLs)))
+				showVideoSelectionDialog(w, resourceURLs, selectionPageSize, startDownload, cancelDownload)
+			})
+		}()
 	}
 
 	downloadPart := container.NewCenter(


### PR DESCRIPTION
## 改动说明

- 新增对 `/AIEducation/detail` 视频详情页的解析支持。
- 新增对 `/AIEducation/list` 视频列表页的解析支持。
- AI 教育列表页可自动展开为视频资源详情链接。
- 修复部分列表页把 `defaultTag` 编码进 `content_id` 后提示“未解析到有效资源”的问题。
- 在点击“仅下载视频”且解析到多个视频时，新增弹窗列表，用户可以勾选要下载的视频。
- 为异常 AI 教育列表链接解析和标签回退逻辑增加单元测试。

## 验证

```powershell
go test ./... -count=1
